### PR TITLE
feat: Use session API token for CCM backend communication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build frontend
 FROM node:22 as build-frontend
-RUN corepack enable
+RUN npm install -g corepack@latest && corepack enable
 WORKDIR /app
 COPY frontend/package*.json ./
 RUN pnpm install

--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ config:
   compatible_versions: []
 ```
 
+In addition, you have to expose the REST API port of the Capella tool in the tool configuration of the Capella tool:
+
+```yml
+config:
+  [...]
+  connection:
+    methods:
+      - [...]
+        ports:
+          metrics: 9118
+          additional:
+            restapi: 5007
+          http: 10000
+```
+
 # Contributing
 
 We'd love to see your bug reports and improvement suggestions! Please take a

--- a/capella_trainer/constants.py
+++ b/capella_trainer/constants.py
@@ -13,9 +13,7 @@ def get_capella_endpoint() -> str | None:
     user_id = os.getenv("CAPELLACOLLAB_SESSION_REQUESTER_USER_ID")
     username = os.getenv("CAPELLACOLLAB_SESSION_REQUESTER_USERNAME")
     session_id = os.getenv("CAPELLACOLLAB_SESSION_ID")
-
-    # this will be replaced with a var from the CCM in the future
-    personal_access_token = os.getenv("PAT_TESTING")
+    personal_access_token = os.getenv("CAPELLACOLLAB_SESSION_API_TOKEN")
 
     if (
         backend_url is None


### PR DESCRIPTION
In https://github.com/DSD-DBS/capella-collab-manager/pull/1710, support for session API tokens was added. 